### PR TITLE
Add agent label, add log group for firehose logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ Give your Cloudformation a few minutes to be created, and that's it!
 
 ## Changelog:
 
+
+- **1.1.1**:
+  - Add label `logzio_agent_version` to `aws_resouece_info` metrics.
 - **1.1.0**:
   - Support adding all namespaces by setting `awsNamespaces` with `all-namespaces`.
   - Tags function: fix EBS service details.

--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ Give your Cloudformation a few minutes to be created, and that's it!
 ## Changelog:
 
 
-- **1.1.1**:
+- **1.2.0**:
   - Add label `logzio_agent_version` to `aws_resouece_info` metrics.
+  - Create log group and log stream for Firehose Delivery Stream.
 - **1.1.0**:
   - Support adding all namespaces by setting `awsNamespaces` with `all-namespaces`.
   - Tags function: fix EBS service details.

--- a/aws/sam-template.yaml
+++ b/aws/sam-template.yaml
@@ -44,6 +44,16 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName: !Join ['-', ['logzio-metric-stream-backup', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+  logzioFirehoseLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Join ['-', ['logzio-metric-stream-firehose', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+  logzioLogStream:
+    DependsOn: logzioFirehoseLogGroup
+    Type: AWS::Logs::LogStream
+    Properties:
+      LogGroupName: !Ref logzioFirehoseLogGroup
+      LogStreamName: !Join ['-', ['logzio-metric-stream-firehose', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
   logzioS3DestinationFirehoseRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -78,6 +88,41 @@ Resources:
                   - !Sub
                     - 'arn:aws:s3:::${BucketName}/*'
                     - BucketName: !Ref logzioS3BackupBucket
+              - Effect: Allow
+                Action:
+                  - 'logs:PutLogEvents'
+                Resource:
+                  - !Sub
+                    - 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${NewLogGroupName}:${NewLogStreamName}:*'
+                    - NewLogGroupName: !Ref logzioFirehoseLogGroup
+                      NewLogStreamName: !Ref logzioLogStream
+  logzioFirehoseLoggingRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: !Join [ '-', [ 'LogzioFirehoseLoggingRole', !Select [ 4, !Split [ '-', !Select [ 2, !Split [ '/', !Ref AWS::StackId ] ] ] ] ] ]
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - firehose.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+      Policies:
+        - PolicyName: !Join [ '-', [ 'LogzioFirehoseLoggingPolicy', !Select [ 4, !Split [ '-', !Select [ 2, !Split [ '/', !Ref AWS::StackId ] ] ] ] ] ]
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - 'logs:PutLogEvents'
+                Resource:
+                  - !Sub
+                    - 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:${NewLogGroupName}:${NewLogStreamName}:*'
+                    - NewLogGroupName: !Ref logzioFirehoseLogGroup
+                      NewLogStreamName: !Ref logzioLogStream
   logzioDeliveryStream:
     DependsOn: logzioS3BackupBucket
     Type: AWS::KinesisFirehose::DeliveryStream
@@ -85,6 +130,7 @@ Resources:
       DeliveryStreamName: !Join ['-', ['LogzioDeliveryStream', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
       DeliveryStreamType: DirectPut
       HttpEndpointDestinationConfiguration:
+        RoleArn: !GetAtt logzioFirehoseLoggingRole.Arn
         BufferingHints:
           IntervalInSeconds: !Ref httpEndpointDestinationIntervalInSeconds
           SizeInMBs: !Ref httpEndpointDestinationSizeInMBs
@@ -98,6 +144,11 @@ Resources:
         S3Configuration:
           BucketARN: !GetAtt logzioS3BackupBucket.Arn
           RoleARN: !GetAtt logzioS3DestinationFirehoseRole.Arn
+        CloudWatchLoggingOptions:
+          Enabled: true
+          LogGroupName: !Ref logzioFirehoseLogGroup
+          LogStreamName: !Ref logzioLogStream
+
   logzioMetricStreamRole:
     Type: 'AWS::IAM::Role'
     Properties:

--- a/tags/README.md
+++ b/tags/README.md
@@ -15,6 +15,8 @@ This Lambda collects tags from resources under selected AWS namespaces, and send
 
 #### Changelog:
 
+- **1.1.1**:
+  - Add label `logzio_agent_version` to metrics.
 - **1.1.0**:
   - Support adding all namespaces by setting `AWS_NAMESPACES` with `all-namespaces`.
   - Fix EBS service details

--- a/tags/main.go
+++ b/tags/main.go
@@ -19,13 +19,15 @@ import (
 )
 
 const (
-	envAwsRegion             = "AWS_REGION" // reserved env
-	envAwsNamespaces         = "AWS_NAMESPACES"
-	envLogzioMetricsListener = "LOGZIO_METRICS_LISTENER"
-	envLogzioMetricsToken    = "LOGZIO_METRICS_TOKEN"
+	envAwsRegion                = "AWS_REGION" // reserved env
+	envAwsNamespaces            = "AWS_NAMESPACES"
+	envLogzioMetricsListener    = "LOGZIO_METRICS_LISTENER"
+	envLogzioMetricsToken       = "LOGZIO_METRICS_TOKEN"
+	envAwsLambdaFunctionVersion = "AWS_LAMBDA_FUNCTION_VERSION" // reserved env
 
-	emptyString   = ""
-	listSeparator = ","
+	emptyString             = ""
+	listSeparator           = ","
+	fieldLogzioAgentVersion = "logzio_agent_version"
 )
 
 var logger = log.New(os.Stdout, "", log.Ldate|log.Ltime|log.Lshortfile)
@@ -210,6 +212,11 @@ func sendTags(ctx context.Context, resources []*resourcegroupstaggingapi.Resourc
 		} else {
 			attributes = append(attributes, idLabels...)
 		}
+
+		attributes = append(attributes, attribute.KeyValue{
+			Key:   fieldLogzioAgentVersion,
+			Value: attribute.StringValue(os.Getenv(envAwsLambdaFunctionVersion)),
+		})
 
 		counter.Add(ctx, int64(1), attributes...)
 	}


### PR DESCRIPTION
In this PR:
- Add to the tags metrics (`aws_resouece_info`) a new label - `logzio_agent_version`.
- Create log group and log stream for Firehose delivery stream.