### PR TITLE
update auto releaseworkflow versions

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -8,19 +8,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: git fetch --force --tags
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.18'
+          go-version: '1.22.2'
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v4
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
- `actions/checkout@v3` >> `actions/checkout@v4`
- `actions/setup-go@v3` >> `actions/setup-go@v5`
- go version `1.18` >> go version `1.22.2`
- `crazy-max/ghaction-import-gpg@v4` >> `crazy-max/ghaction-import-gpg@v6`
- `goreleaser/goreleaser-action@v2` >> `goreleaser/goreleaser-action@v5`